### PR TITLE
Compile g729 codec from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN echo "Package: *" >> /etc/apt/preferences.d/bullseye && \
             build-essential \
             ca-certificates \
             curl \
+            cmake \
             libcurl4-openssl-dev \
             libedit-dev \
             libgsm1-dev \
@@ -32,6 +33,7 @@ RUN echo "Package: *" >> /etc/apt/preferences.d/bullseye && \
             libsqlite3-dev \
             libsrtp0-dev \
             libssl-dev \
+            libtool \
             libvorbis-dev \
             libxml2-dev \
             libxslt1-dev \
@@ -67,5 +69,12 @@ ENV ASTERISK_VERSION=17.2.0
 COPY build-asterisk.sh /build-asterisk
 COPY bfd.patch /var/
 RUN DEBIAN_FRONTEND=noninteractive /build-asterisk
+
+# Install g729
+RUN git clone https://github.com/BelledonneCommunications/bcg729.git && cd bcg729 && \
+    cmake . && make && make install && cd .. && rm -r bcg729 && \
+    git clone https://github.com/arkadijs/asterisk-g72x.git && cd asterisk-g72x && \
+    ./autogen.sh && ./configure --with-bcg729 && make && make install && \
+    cd .. && rm -r asterisk-g72x
 
 CMD ["/usr/sbin/asterisk", "-f"]

--- a/build-asterisk.sh
+++ b/build-asterisk.sh
@@ -49,10 +49,6 @@ mkdir -p /etc/asterisk/
 # copy default configs
 make basic-pbx
 
-#add codec g729
-wget http://asterisk.hosting.lv/bin/codec_g729-ast170-gcc4-glibc-x86_64-core2.so -O codec_g729.so
-mv codec_g729.so /usr/lib/asterisk/modules/
-
 # set runuser and rungroup
 sed -i -E 's/^;(run)(user|group)/\1\2/' /etc/asterisk/asterisk.conf
 


### PR DESCRIPTION
The g729 library used was compiled with gcc 4, which is as old as 2015.
By compiling from source we can use a modern gcc version and better 
optimizations.